### PR TITLE
use existing CircleCI env var for GitHub repo url

### DIFF
--- a/github-maven-deploy.yml
+++ b/github-maven-deploy.yml
@@ -115,7 +115,7 @@ commands:
             echo "Pushing new version and tag..."
             git commit -am "released ${MVN_VERSION} [skip ci]"
             git tag -a ${MVN_VERSION} -m "Release ${MVN_VERSION}"
-            ssh-agent sh -c 'ssh-add ~/.ssh/id_rsa; git push $GITHUB_REPO'
+            ssh-agent sh -c 'ssh-add ~/.ssh/id_rsa; git push $CIRCLE_REPOSITORY_URL'
             ssh-agent sh -c 'ssh-add ~/.ssh/id_rsa; git push origin --tags'
             echo "Succesfully released ${MVN_VERSION}"
       - save_cache:


### PR DESCRIPTION
Replaces use of manually defined GITHUB_REPO env var with automatically defined CIRCLE_REPOSITORY_URL env var

Should also probably remove docs references to GITHUB_REPO env var.